### PR TITLE
[REFINE](server): Clean up comments in send_welcome function for clarity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ tests_run:
 
 normalize:
 	@echo "Applying clang format to all C++ files..."
-	@find ./client -type f \( -name "*.cpp" -o -name "*.hpp" \) -exec $(CLANG_FORMAT) -i -style=llvm {} \;
+	@find ./client -type f \( -name "*.cpp" -o -name "*.hpp" \) \
+	-exec $(CLANG_FORMAT) -i -style=llvm {} \;
 	@echo "Formatting complete!"
 
 clean:

--- a/server/send_messages_to_clients.c
+++ b/server/send_messages_to_clients.c
@@ -10,7 +10,7 @@
 void send_welcome(int client_fd, uint8_t assigned_id)
 {
     uint8_t buffer[4 + 2];
-    uint16_t length = 4 + 2;  // Raw length, not converted to network byte order
+    uint16_t length = 4 + 2;
     ssize_t bytes_sent;
 
     write_header(buffer, SERVER_WELCOME, length);


### PR DESCRIPTION
This pull request includes minor formatting and cleanup changes to the codebase. The changes focus on improving code readability and consistency without altering functionality.

### Code formatting improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L41-R42): Adjusted the formatting of the `find` command in the `normalize` target to improve readability by placing the `-exec` option on a new line.

### Code cleanup:
* [`server/send_messages_to_clients.c`](diffhunk://#diff-ed1b722a697667bddc3f2346a871ccb60fb90816d83c459fd17a32484c0f3484L13-R13): Removed an outdated comment describing the `length` variable, as it was redundant and did not add value to the code.