### PR TITLE
Send to write function

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -5,4 +5,4 @@ set(CMAKE_C_STANDARD 11)  # Définit la version du standard C
 set(CMAKE_C_FLAGS "-Wall -Wextra -Werror")  # Active les warnings
 
 # Ajoute le fichier source
-add_executable(jetpack_server server.c main.c error_handling.c put_str_fd.c set_server.c check_args.c handle_client.c parsing.c load_map.c read_client.c send_messages_to_clients.c write_messages.c launch_game.c game_loop.c send_game_messages.c handle_input_from_clients.c)
+add_executable(jetpack_server server.c main.c error_handling.c put_str_fd.c set_server.c check_args.c handle_client.c parsing.c load_map.c read_client.c send_messages_to_clients.c write_messages.c launch_game.c game_loop.c send_game_messages.c handle_input_from_clients.c send_function.c)

--- a/server/includes/server.h
+++ b/server/includes/server.h
@@ -116,6 +116,7 @@ void read_client(server_t *server, int i);
 void handle_input(server_t *server, int client_id, char *payload,
     uint16_t len);
 
+bool send_with_write(int fd, const void *buffer, size_t length);
 void parsing_launch(int argc, char **argv, server_t *server);
 void put_str_fd(int fd, char *str);
 void load_map(server_t *server);

--- a/server/send_function.c
+++ b/server/send_function.c
@@ -1,0 +1,18 @@
+/*
+** EPITECH PROJECT, 2025
+** Jetpack
+** File description:
+** send_function
+*/
+
+#include "includes/server.h"
+#include <unistd.h>
+
+bool send_with_write(int fd, const void *buffer, size_t length)
+{
+    ssize_t bytes_written = write(fd, buffer, length);
+
+    if (bytes_written == -1)
+        return false;
+    return true;
+}

--- a/server/send_function.c
+++ b/server/send_function.c
@@ -10,9 +10,15 @@
 
 bool send_with_write(int fd, const void *buffer, size_t length)
 {
-    ssize_t bytes_written = write(fd, buffer, length);
+    const char *buf = (const char *)buffer;
+    size_t total_written = 0;
+    ssize_t bytes_written;
 
-    if (bytes_written == -1)
-        return false;
+    while (total_written < length) {
+        bytes_written = write(fd, buf + total_written, length - total_written);
+        if (bytes_written == -1)
+            return false;
+        total_written += bytes_written;
+    }
     return true;
 }

--- a/server/send_function.c
+++ b/server/send_function.c
@@ -16,7 +16,7 @@ bool send_with_write(int fd, const void *buffer, size_t length)
 
     while (total_written < length) {
         bytes_written = write(fd, buf + total_written, length - total_written);
-        if (bytes_written == -1)
+        if (bytes_written == -1 || bytes_written == 0)
             return false;
         total_written += bytes_written;
     }

--- a/server/send_game_messages.c
+++ b/server/send_game_messages.c
@@ -11,14 +11,11 @@ void send_game_start(server_t *server, int client_fd)
 {
     uint8_t buffer[9];
     uint16_t length = 9;
-    ssize_t bytes_sent;
 
     write_header(buffer, GAME_START, length);
     write_start_payload(buffer, server);
-    bytes_sent = send(client_fd, buffer, sizeof(buffer), 0);
-    if (bytes_sent == -1) {
-        perror("send");
-    }
+    if (!send_with_write(client_fd, buffer, sizeof(buffer)))
+        perror("send_with_write GAME_START");
 }
 
 void send_game_state(server_t *server, int client_fd)
@@ -40,8 +37,8 @@ void send_game_state(server_t *server, int client_fd)
         write_data_state_payload(buffer, client, offset, i);
         offset += 9;
     }
-    if (send(client_fd, buffer, total_msg_size, 0) == -1)
-        perror("send GAME_STATE");
+    if (!send_with_write(client_fd, buffer, total_msg_size))
+        perror("send_with_write GAME_STATE");
     free(buffer);
 }
 

--- a/server/send_messages_to_clients.c
+++ b/server/send_messages_to_clients.c
@@ -11,22 +11,18 @@ void send_welcome(int client_fd, uint8_t assigned_id)
 {
     uint8_t buffer[4 + 2];
     uint16_t length = 4 + 2;  // Raw length, not converted to network byte order
-    ssize_t bytes_sent;
 
     write_header(buffer, SERVER_WELCOME, length);
     buffer[4] = 1;
     buffer[5] = assigned_id;
-    bytes_sent = send(client_fd, buffer, sizeof(buffer), 0);
-    if (bytes_sent == -1) {
-        perror("send");
-    }
+    if (!send_with_write(client_fd, buffer, sizeof(buffer)))
+        perror("send_with_write SERVER_WELCOME");
 }
 
 void send_map_chunk(server_t *server, int client_fd, uint8_t col_index)
 {
     size_t total_size;
     uint8_t *buffer;
-    ssize_t bytes_sent;
 
     if (col_index >= server->map_cols)
         return;
@@ -38,9 +34,8 @@ void send_map_chunk(server_t *server, int client_fd, uint8_t col_index)
     write_map_payload(buffer, col_index, (uint16_t)server->map_cols);
     for (size_t row = 0; row < server->map_rows; row++)
         buffer[8 + row] = server->map[row][col_index];
-    bytes_sent = send(client_fd, buffer, total_size, 0);
-    if (bytes_sent == -1)
-        perror("send");
+    if (!send_with_write(client_fd, buffer, total_size))
+        perror("send_with_write MAP_CHUNK");
     free(buffer);
 }
 


### PR DESCRIPTION
This pull request introduces a new utility function, `send_with_write`, to streamline and standardize the process of sending data over sockets in the server code. The changes replace direct calls to `send` with this new function, improving error handling consistency. Additionally, the `send_function.c` file was added to encapsulate this functionality.

### Introduction of `send_with_write` utility function:

* Added a new file, `server/send_function.c`, which implements the `send_with_write` function to wrap the `write` system call for sending data. This function returns a `bool` indicating success or failure. (`[server/send_function.cR1-R18](diffhunk://#diff-dc3a0a63d92f1877bec184ab8cd78ca4b7b6184ea5fd34387b5310b84cc6418fR1-R18)`)
* Declared the `send_with_write` function in the `server/includes/server.h` header file for global usage. (`[server/includes/server.hR119](diffhunk://#diff-c8174027fa09ad78f2c8c62bf188fc19031819c4275395bd565863a7ffd2052cR119)`)

### Refactoring to use `send_with_write`:

* Replaced direct calls to `send` in `send_game_start` and `send_game_state` functions in `server/send_game_messages.c` with `send_with_write`. This improves error handling consistency with descriptive error messages. (`[[1]](diffhunk://#diff-1fb4228ffc622eed8c1082fd216bed3ccb6b054f428db1f5940d0fa73b907f75L14-R18)`, `[[2]](diffhunk://#diff-1fb4228ffc622eed8c1082fd216bed3ccb6b054f428db1f5940d0fa73b907f75L43-R41)`)
* Updated `send_welcome` and `send_map_chunk` functions in `server/send_messages_to_clients.c` to use `send_with_write` instead of `send`. This ensures uniform error handling across the codebase. (`[[1]](diffhunk://#diff-ed1b722a697667bddc3f2346a871ccb60fb90816d83c459fd17a32484c0f3484L14-L29)`, `[[2]](diffhunk://#diff-ed1b722a697667bddc3f2346a871ccb60fb90816d83c459fd17a32484c0f3484L41-R38)`)

### Build system update:

* Modified the `server/CMakeLists.txt` file to include the newly added `send_function.c` in the build process. (`[server/CMakeLists.txtL8-R8](diffhunk://#diff-557b764d93c625467726335e930bdb5e8b625a3709e76d8afbcac860d455e5c8L8-R8)`)