### PR TITLE
[FIX](CI): Refactor coding style check workflow

### DIFF
--- a/.github/workflows/ci-mirror.yml
+++ b/.github/workflows/ci-mirror.yml
@@ -25,22 +25,27 @@ jobs:
         run: make tests_run
 
   coding_style:
-    name: Coding Style Check
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
+    container:
+        image: "ghcr.io/epitech/coding-style-checker:latest"
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
+        -   name: "Check coding style"
+            run: "/usr/local/bin/check.sh $(pwd) $(pwd)"
 
-      - name: Create Reports Directory
-        run: mkdir -p reports
+        -   name: "Annotate coding-style errors"
+            run: |
+                status=0
+                while IFS= read -r line; do
+                    file=$(echo "${line}" | cut -d ':' -f1)
+                    pos=$(echo "${line}" | cut -d ':' -f2)
+                    type=$(echo "${line}" | cut -d ':' -f3)
+                    csid=$(echo "${line}" | cut -d ':' -f4)
 
-      - name: Download Coding Style Checker
-        run: |
-          curl -L https://raw.githubusercontent.com/Epitech/coding-style-checker/refs/heads/main/coding-style.sh -o coding-style.sh
-          chmod +x coding-style.sh
-
-      - name: Run Coding Style Checker
-        run: ./coding-style.sh . reports
+                    [[ "${type:1}" == "illegal"* ]] && continue
+                    echo "::error file=${file},line=${pos},title=${type:1} ${csid}::${type:1}: ${csid} at ${file}:${pos}"
+                    status=1
+                done < coding-style-reports.log
+                exit "${status}"
 
   mirror:
     name: Mirror to Epitech Repository


### PR DESCRIPTION
This pull request updates the CI workflow configuration to streamline and modernize the coding style check process. The changes include switching to a containerized coding style checker and simplifying the steps for error annotation.

### Updates to CI workflow:
* **Containerized coding style checker**: Replaced manual setup of the coding style checker with a prebuilt container image (`ghcr.io/epitech/coding-style-checker:latest`), simplifying setup and ensuring consistency. (`[.github/workflows/ci-mirror.ymlL28-R48](diffhunk://#diff-9a36ce38b758835233236b8c0f526c25557c5683f9577bad44e864f2c0210bbdL28-R48)`)
* **Simplified error annotation**: Introduced a streamlined process to annotate coding style errors directly from a log file (`coding-style-reports.log`) using GitHub Actions' workflow commands. (`[.github/workflows/ci-mirror.ymlL28-R48](diffhunk://#diff-9a36ce38b758835233236b8c0f526c25557c5683f9577bad44e864f2c0210bbdL28-R48)`)