### PR TITLE
Client integration

### DIFF
--- a/client/gamestate.cpp
+++ b/client/gamestate.cpp
@@ -19,9 +19,9 @@ void GameState::setAssignedId(uint8_t id) {
 
 void GameState::setGameRunning(bool running) { gameRunning = running; }
 
-void GameState::setInputMask(uint8_t mask) {
+void GameState::setJetpackActive(bool active) {
   std::lock_guard<std::mutex> lock(mutex_);
-  inputMask = mask;
+  jetpackActive = active;
 }
 
 void GameState::setMapDimensions(uint16_t width, uint16_t height) {
@@ -62,9 +62,9 @@ uint8_t GameState::getAssignedId() const {
 
 bool GameState::isGameRunning() const { return gameRunning; }
 
-uint8_t GameState::getInputMask() const {
+bool GameState::isJetpackActive() const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return inputMask;
+  return jetpackActive;
 }
 
 std::pair<uint16_t, uint16_t> GameState::getMapDimensions() const {

--- a/client/gamestate.hpp
+++ b/client/gamestate.hpp
@@ -19,7 +19,7 @@ namespace jetpack {
 class GameState {
 public:
   GameState()
-      : connected(false), assignedId(0), gameRunning(false), inputMask(0),
+      : connected(false), assignedId(0), gameRunning(false), jetpackActive(false),
         mapWidth(0), mapHeight(0), currentTick(0), gameEnded(false),
         winnerId(0xFF) {}
 
@@ -27,7 +27,7 @@ public:
   void setConnected(bool status);
   void setAssignedId(uint8_t id);
   void setGameRunning(bool running);
-  void setInputMask(uint8_t mask);
+  void setJetpackActive(bool active);
   void setMapDimensions(uint16_t width, uint16_t height);
   void addMapChunk(const std::vector<uint8_t> &chunkData);
   void setPlayerStates(const std::vector<protocol::PlayerState> &states);
@@ -38,7 +38,7 @@ public:
   bool isConnected() const;
   uint8_t getAssignedId() const;
   bool isGameRunning() const;
-  uint8_t getInputMask() const;
+  bool isJetpackActive() const;
   std::pair<uint16_t, uint16_t> getMapDimensions() const;
   std::vector<uint8_t> getMapData() const;
   std::vector<protocol::PlayerState> getPlayerStates() const;
@@ -51,7 +51,7 @@ private:
   std::atomic<bool> connected;
   uint8_t assignedId;
   std::atomic<bool> gameRunning;
-  uint8_t inputMask;
+  bool jetpackActive;
 
   // Map data
   uint16_t mapWidth;

--- a/client/graphics/graphics.cpp
+++ b/client/graphics/graphics.cpp
@@ -340,32 +340,12 @@ void Graphics::renderDebugInfo() {
 }
 
 void Graphics::handleKeyPress(sf::Keyboard::Key key, bool isPressed) {
-  uint8_t currentMask = gameState_->getInputMask();
-  uint8_t newMask = currentMask;
+  bool jetpackCurrentlyActive = gameState_->isJetpackActive();
+  bool newJetpackState = jetpackCurrentlyActive;
 
   switch (key) {
-  case sf::Keyboard::Left:
-    if (isPressed) {
-      newMask |= protocol::MOVE_LEFT;
-    } else {
-      newMask &= ~protocol::MOVE_LEFT;
-    }
-    break;
-
-  case sf::Keyboard::Right:
-    if (isPressed) {
-      newMask |= protocol::MOVE_RIGHT;
-    } else {
-      newMask &= ~protocol::MOVE_RIGHT;
-    }
-    break;
-
   case sf::Keyboard::Space:
-    if (isPressed) {
-      newMask |= protocol::JETPACK;
-    } else {
-      newMask &= ~protocol::JETPACK;
-    }
+    newJetpackState = isPressed;
     break;
 
   case sf::Keyboard::Escape:
@@ -378,8 +358,8 @@ void Graphics::handleKeyPress(sf::Keyboard::Key key, bool isPressed) {
     return;
   }
 
-  if (newMask != currentMask) {
-    gameState_->setInputMask(newMask);
+  if (newJetpackState != jetpackCurrentlyActive) {
+    gameState_->setJetpackActive(newJetpackState);
   }
 }
 

--- a/client/graphics/graphics.cpp
+++ b/client/graphics/graphics.cpp
@@ -328,9 +328,7 @@ void Graphics::renderDebugInfo() {
      << std::endl
      << "Game Running: " << (gameState_->isGameRunning() ? "Yes" : "No")
      << std::endl
-     << "Current Tick: " << gameState_->getCurrentTick() << std::endl
-     << "Input Mask: 0x" << std::hex << std::setw(2) << std::setfill('0')
-     << static_cast<int>(gameState_->getInputMask());
+     << "Current Tick: " << gameState_->getCurrentTick() << std::endl;
 
   debugText.setString(ss.str());
   debugText.setCharacterSize(12);

--- a/client/network/network.cpp
+++ b/client/network/network.cpp
@@ -314,25 +314,21 @@ bool Network::receivePacket(protocol::PacketHeader *header,
 void Network::sendPlayerInput() {
   std::vector<uint8_t> payload;
   uint8_t playerId = gameState_->getAssignedId();
-  uint8_t inputMask = gameState_->getInputMask();
+  uint8_t jetpackState = gameState_->isJetpackActive() ? 
+                        protocol::JETPACK_ON : protocol::JETPACK_OFF;
 
   payload.push_back(playerId);
-  payload.push_back(inputMask);
-
-  // Optional sequence number could be added here
+  payload.push_back(jetpackState);
 
   sendPacket(protocol::CLIENT_INPUT, payload);
 
-  // Log when input mask changes
-  static uint8_t lastInputMask = 0;
-  if (inputMask != lastInputMask) {
+  // Log when jetpack state changes
+  static uint8_t lastJetpackState = 0xFF; // Initialize to invalid value to ensure first log
+  if (jetpackState != lastJetpackState) {
     std::stringstream ss;
-    ss << "Input changed: 0x" << std::hex << static_cast<int>(inputMask)
-       << std::dec << " (L:" << (inputMask & protocol::MOVE_LEFT ? "1" : "0")
-       << " R:" << (inputMask & protocol::MOVE_RIGHT ? "1" : "0")
-       << " J:" << (inputMask & protocol::JETPACK ? "1" : "0") << ")";
+    ss << "Input changed: Jetpack=" << (jetpackState == protocol::JETPACK_ON ? "ON" : "OFF");
     debug::logToFile("Network", ss.str(), debugMode_);
-    lastInputMask = inputMask;
+    lastJetpackState = jetpackState;
   }
 }
 

--- a/client/protocol.hpp
+++ b/client/protocol.hpp
@@ -37,12 +37,10 @@ enum GameEndReason : uint8_t {
   PLAYER_DISCONNECT = 0x03
 };
 
-// Input mask bits
-enum InputMask : uint8_t {
-  MOVE_LEFT = 0x01,  // bit 0
-  MOVE_RIGHT = 0x02, // bit 1
-  JETPACK = 0x04     // bit 2
-  // bits 3-7 reserved
+// Jetpack state values
+enum JetpackState : uint8_t {
+  JETPACK_OFF = 0x00,  // Falling
+  JETPACK_ON = 0x01    // Ascending
 };
 
 // Header structure (4 bytes)


### PR DESCRIPTION
This pull request replaces the `inputMask` system with a simplified `jetpackActive` boolean to manage the jetpack state in the game. The change removes bitmask-based input handling and introduces a more focused approach for jetpack functionality. Below are the most important changes grouped by theme:

### GameState Refactoring
* Replaced `inputMask` with `jetpackActive` in the `GameState` class, including its constructor, methods, and member variables. Updated `setInputMask` to `setJetpackActive` and `getInputMask` to `isJetpackActive` for clarity and functionality. (`client/gamestate.cpp`: [[1]](diffhunk://#diff-41226ac8b7faf0588d504dcef7e4f25cc721b0b3ad4521770a59ec5401bd25f5L22-R24) [[2]](diffhunk://#diff-41226ac8b7faf0588d504dcef7e4f25cc721b0b3ad4521770a59ec5401bd25f5L65-R67); `client/gamestate.hpp`: [[3]](diffhunk://#diff-e58d0a4e276be1a8ef7e9957dba14dbef8e365670570e4430eb321a2a6f91af8L22-R30) [[4]](diffhunk://#diff-e58d0a4e276be1a8ef7e9957dba14dbef8e365670570e4430eb321a2a6f91af8L41-R41) [[5]](diffhunk://#diff-e58d0a4e276be1a8ef7e9957dba14dbef8e365670570e4430eb321a2a6f91af8L54-R54)

### Graphics Input Handling
* Updated `Graphics::handleKeyPress` to toggle the `jetpackActive` state directly using the `Space` key, removing the handling of other movement-related keys like `Left` and `Right`. (`client/graphics/graphics.cpp`: [[1]](diffhunk://#diff-fa61daa8d4b2705bc7d3a1b0a3c5299a26cd99a4cbe0b96e859b177e4cc8f562L343-R346) [[2]](diffhunk://#diff-fa61daa8d4b2705bc7d3a1b0a3c5299a26cd99a4cbe0b96e859b177e4cc8f562L381-R360)
* Removed the display of `inputMask` in `Graphics::renderDebugInfo`. (`client/graphics/graphics.cpp`: [client/graphics/graphics.cppL331-R331](diffhunk://#diff-fa61daa8d4b2705bc7d3a1b0a3c5299a26cd99a4cbe0b96e859b177e4cc8f562L331-R331))

### Networking Updates
* Updated `Network::sendPlayerInput` to send the `jetpackActive` state as a `JetpackState` enum (`JETPACK_ON` or `JETPACK_OFF`) instead of the `inputMask`. Simplified the logging mechanism to reflect the jetpack state changes. (`client/network/network.cpp`: [client/network/network.cppL317-R331](diffhunk://#diff-80eb415870b45f32f51cbaee8e31fd9c1deda53901206f0afa68e07d50c48119L317-R331))

### Protocol Changes
* Replaced the `InputMask` enum with a `JetpackState` enum to represent the jetpack's on/off states, removing unused movement-related flags. (`client/protocol.hpp`: [client/protocol.hppL40-R43](diffhunk://#diff-eb09f6c90a16d27755bc1db00d65dc75641d4300b8c6eba9ecd899c87ece4437L40-R43))