### PR TITLE
[FIX](server): Correct jetpack position calculation and update debug …

### DIFF
--- a/server/check_in_game.c
+++ b/server/check_in_game.c
@@ -79,7 +79,7 @@ void process_client_state(client_t *client, server_t *server,
 void check_jetpack(client_t *client, server_t *server)
 {
     if (client->jetpack) {
-        client->y = client->y < 40 ? 0 :
+        client->y = client->y < client->y - (5 * 100 / server->map_rows) ? 0 :
         client->y - (5 * 100 / server->map_rows);
     } else
         client->y += (3 * 100 / server->map_rows);

--- a/server/main.c
+++ b/server/main.c
@@ -14,6 +14,8 @@ void display_help(void)
 
 int main(int argc, char **argv)
 {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
     if (argc == 1) {
         display_help();
         return 84;

--- a/server/print_debug.c
+++ b/server/print_debug.c
@@ -30,7 +30,6 @@ void print_debug_info_connection(server_t *server, char *context)
     strftime(time_buf, sizeof(time_buf), "%H:%M:%S", tm_info);
     printf("[%s][%s] Connecting on the port %i \n",
         time_buf, context, server->port);
-    fflush(stdout);
 }
 
 void print_debug_info_package_received(server_t *server, char *context,
@@ -45,7 +44,6 @@ void print_debug_info_package_received(server_t *server, char *context,
     type = get_type_string_prev(server->message_type);
     printf("[%s][%s] Received packet: type=0x%02X (%s), length=%u bytes\n",
         time_buf, context, server->message_type, type, payload_length);
-    fflush(stdout);
 }
 
 void print_debug_info_package_sent(server_t *server,

--- a/server/send_game_messages.c
+++ b/server/send_game_messages.c
@@ -40,7 +40,7 @@ void send_game_state(server_t *server, int client_fd)
     if (!send_with_write(client_fd, buffer, total_msg_size))
         perror("send_with_write GAME_STATE");
     print_debug_info_package_sent(server, get_type_string_prev(buffer[1]),
-        buffer, sizeof(buffer));
+        buffer, total_msg_size);
     free(buffer);
 }
 

--- a/server/server.c
+++ b/server/server.c
@@ -12,7 +12,6 @@ void close_everything(server_t *server)
     for (int i = 0; i < server->client_count; i++) {
         close(server->client[i]->fd);
         free(server->client[i]);
-        server->client_count--;
     }
     free(server);
 }


### PR DESCRIPTION
This pull request includes several updates to the server codebase, focusing on gameplay mechanics, debugging output, and memory management. The most important changes include refining jetpack mechanics, improving debugging output handling, and fixing an issue with client cleanup during server shutdown.

### Gameplay Mechanics:
* [`server/check_in_game.c`](diffhunk://#diff-6b37b31c5ee929e9a888d3f59c692b338514e6a290f8d933f303cd1e5d1bbb17L82-R82): Adjusted the jetpack movement logic to ensure the player's `y` position decreases dynamically based on the map's row count, improving gameplay responsiveness.

### Debugging Output:
* [`server/main.c`](diffhunk://#diff-c26839d231d8c906121bec0c751b467958600e163ac1ee31c58a32a12bf89e80R17-R18): Added `setbuf` calls to disable buffering for `stdout` and `stderr`, ensuring immediate output of debug and error messages.
* [`server/print_debug.c`](diffhunk://#diff-f8d3f3a6e4b8361b20c1be4165bdbd7dd0b654ae8dc507d7866397ab0045871cL33): Removed redundant `fflush(stdout)` calls from debug print functions, as they are no longer necessary with unbuffered output. [[1]](diffhunk://#diff-f8d3f3a6e4b8361b20c1be4165bdbd7dd0b654ae8dc507d7866397ab0045871cL33) [[2]](diffhunk://#diff-f8d3f3a6e4b8361b20c1be4165bdbd7dd0b654ae8dc507d7866397ab0045871cL48)

### Memory Management:
* [`server/server.c`](diffhunk://#diff-c025462b65af221e5a56873e134ccaf3586bc9976421febd74add6df061a41d0L15): Fixed a bug in `close_everything` where the `client_count` was being decremented unnecessarily during client cleanup, preventing potential inconsistencies.

### Message Handling:
* [`server/send_game_messages.c`](diffhunk://#diff-1fb4228ffc622eed8c1082fd216bed3ccb6b054f428db1f5940d0fa73b907f75L43-R43): Updated the `send_game_state` function to use the correct message size when logging debug information about sent game state packets.…print functions