### PR TITLE
Fix memory leaks

### DIFF
--- a/bonus/client/graphics/renderer.cpp
+++ b/bonus/client/graphics/renderer.cpp
@@ -489,7 +489,7 @@ void Renderer::renderGameEndScreen(sf::RenderWindow *window,
     ss << "Player " << static_cast<int>(player.id) << ": " << player.score
        << " points";
     if (player.id == localPlayerId) {
-      ss << " (You)";
+      ss << " (gest)";
     }
     if (!player.alive) {
       ss << " [DEAD]";

--- a/bonus/server/check_in_game.c
+++ b/bonus/server/check_in_game.c
@@ -8,11 +8,10 @@
 #include "includes/server.h"
 
 
-bool check_limits(client_t *client)
+void check_limits(client_t *client)
 {
     if (client->x >= 1000) {
         client->x = 1000 - 1;
-        return true;
     }
     if (client->x <= 0)
         client->x = 0;
@@ -20,7 +19,6 @@ bool check_limits(client_t *client)
         client->y = 1000 - 1;
     if (client->y <= 0)
         client->y = 0;
-    return false;
 }
 
 void check_entities_collisions(client_t *client, server_t *server)
@@ -56,22 +54,20 @@ bool initialize_alive_tracking(server_t *server, int *alive_count,
     return true;
 }
 
-void process_client_state(client_t *client, server_t *server,
-    uint8_t alive_player_id)
+void process_client_state(client_t *client, server_t *server)
 {
     client->collected_coin = false;
     if (!client->is_alive)
         return;
     check_jetpack(client, server);
-    if (check_limits(client))
-        send_game_end(server, 1, alive_player_id);
+    check_limits(client);
     check_entities_collisions(client, server);
 }
 
 void check_jetpack(client_t *client, server_t *server)
 {
     if (client->jetpack) {
-        client->y = client->y < 40 ? 0 :
+        client->y = client->y < client->y - (5 * 100 / server->map_rows) ? 0 :
         client->y - (5 * 100 / server->map_rows);
     } else
         client->y += (3 * 100 / server->map_rows);

--- a/bonus/server/collisions.c
+++ b/bonus/server/collisions.c
@@ -16,7 +16,6 @@ void handle_coin(client_t *client, server_t *server, size_t row, size_t col)
 {
     coin_t *coin;
 
-    client->score++;
     server->map[row][col] = 'd';
     client->collected_coin = true;
     for (size_t i = 0; i < server->coin_count; i++) {

--- a/bonus/server/game_loop.c
+++ b/bonus/server/game_loop.c
@@ -7,24 +7,47 @@
 
 #include "includes/server.h"
 
+void check_win(client_t *client, uint8_t *winner_id, int *max_score, int i)
+{
+    if (client->x >= 999 && client->is_alive) {
+        if (client->score > *max_score) {
+            *max_score = client->score;
+            *winner_id = i;
+        }
+    }
+}
+
+int check_life(client_t *client, int alive_count, uint8_t *alive_player_id,
+    int i)
+{
+    if (client->is_alive) {
+        alive_count++;
+        *alive_player_id = i;
+    }
+    return alive_count;
+}
+
 void update_game_state(server_t *server)
 {
     client_t *client;
     uint8_t alive_player_id = 0xFF;
     int alive_count = 0;
+    uint8_t winner_id = 0xFF;
+    int max_score = -1;
 
     if (!initialize_alive_tracking(server, &alive_count, &alive_player_id))
         return;
     for (int i = 0; i < server->client_count; i++) {
         client = server->client[i];
         read_client(server, i);
-        process_client_state(client, server, alive_player_id);
-        if (client->is_alive) {
-            alive_count++;
-            alive_player_id = i;
-        }
+        process_client_state(client, server);
+        check_win(client, &winner_id, &max_score, i);
+        alive_count = check_life(client, alive_count, &alive_player_id, i);
     }
-    if (!client->is_alive || (alive_count == 1 && server->client_count > 1))
+    if (winner_id != 0xFF) {
+        send_game_end(server, 2, winner_id);
+    } else if (!client->is_alive ||
+        (alive_count == 1 && server->client_count > 1))
         send_game_end(server, 2, alive_player_id);
 }
 

--- a/bonus/server/includes/server.h
+++ b/bonus/server/includes/server.h
@@ -144,12 +144,11 @@ void print_debug_all(server_t *server, char *context, char *payload,
 
 // In game functions
 void check_jetpack(client_t *client, server_t *server);
-bool check_limits(client_t *client);
+void check_limits(client_t *client);
 void check_entities_collisions(client_t *client, server_t *server);
 bool initialize_alive_tracking(server_t *server, int *alive_count,
     uint8_t *alive_player_id);
-void process_client_state(client_t *client, server_t *server,
-    uint8_t alive_player_id);
+void process_client_state(client_t *client, server_t *server);
 bool is_in_bounds(server_t *server, size_t row, size_t col);
 void handle_coin(client_t *client, server_t *server, size_t row, size_t col);
 void handle_electic(client_t *client);

--- a/bonus/server/main.c
+++ b/bonus/server/main.c
@@ -14,6 +14,8 @@ void display_help(void)
 
 int main(int argc, char **argv)
 {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
     if (argc == 1) {
         display_help();
         return 84;

--- a/bonus/server/print_debug.c
+++ b/bonus/server/print_debug.c
@@ -30,7 +30,6 @@ void print_debug_info_connection(server_t *server, char *context)
     strftime(time_buf, sizeof(time_buf), "%H:%M:%S", tm_info);
     printf("[%s][%s] Connecting on the port %i \n",
         time_buf, context, server->port);
-    fflush(stdout);
 }
 
 void print_debug_info_package_received(server_t *server, char *context,
@@ -45,7 +44,6 @@ void print_debug_info_package_received(server_t *server, char *context,
     type = get_type_string_prev(server->message_type);
     printf("[%s][%s] Received packet: type=0x%02X (%s), length=%u bytes\n",
         time_buf, context, server->message_type, type, payload_length);
-    fflush(stdout);
 }
 
 void print_debug_info_package_sent(server_t *server,

--- a/bonus/server/send_game_messages.c
+++ b/bonus/server/send_game_messages.c
@@ -40,7 +40,7 @@ void send_game_state(server_t *server, int client_fd)
     if (!send_with_write(client_fd, buffer, total_msg_size))
         perror("send_with_write GAME_STATE");
     print_debug_info_package_sent(server, get_type_string_prev(buffer[1]),
-        buffer, sizeof(buffer));
+        buffer, total_msg_size);
     free(buffer);
 }
 

--- a/bonus/server/server.c
+++ b/bonus/server/server.c
@@ -15,7 +15,6 @@ void close_everything(server_t *server)
     for (int i = 0; i < server->client_count; i++) {
         close(server->client[i]->fd);
         free(server->client[i]);
-        server->client_count--;
     }
     free(server);
 }

--- a/client/graphics/renderer.cpp
+++ b/client/graphics/renderer.cpp
@@ -426,7 +426,7 @@ void Renderer::renderGameEndScreen(sf::RenderWindow *window,
     ss << "Player " << static_cast<int>(player.id) << ": " << player.score
        << " points";
     if (player.id == localPlayerId) {
-      ss << " (You)";
+      ss << " (guest)";
     }
     if (!player.alive) {
       ss << " [DEAD]";


### PR DESCRIPTION
This pull request introduces several changes to improve game logic, refactor functions for better clarity, and fix minor issues in the server's debug and cleanup processes. The most significant updates include changes to how player limits and game state are handled, the addition of new helper functions for managing game logic, and the removal of redundant code.

### Game Logic Improvements:
* Changed `check_limits` function to return `void` instead of `bool`, simplifying its usage and removing unnecessary return values. (`bonus/server/check_in_game.c`, `bonus/server/includes/server.h`) [[1]](diffhunk://#diff-b810cf78482c8c67008383b5f22ff11b01268e5beb9a2856ce85347969e2c729L11-L23) [[2]](diffhunk://#diff-9898e733903d0bd533b74b246a46e7c18eb342d894c6bbd4b5f378cd8e5812e7L147-R151)
* Added `check_win` and `check_life` helper functions to streamline the logic for determining the winner and tracking alive players during the game loop. (`bonus/server/game_loop.c`)

### Debugging Enhancements:
* Removed redundant `fflush(stdout)` calls from debug functions to avoid unnecessary flushing of output buffers. (`bonus/server/print_debug.c`) [[1]](diffhunk://#diff-84e36a2437d2134ad3c9e683a905f0d0d22f956246b918c653a18038fe921978L33) [[2]](diffhunk://#diff-84e36a2437d2134ad3c9e683a905f0d0d22f956246b918c653a18038fe921978L48)
* Added `setbuf(stdout, NULL)` and `setbuf(stderr, NULL)` in `main` to disable output buffering, ensuring immediate output during debugging. (`bonus/server/main.c`)

### Code Cleanup:
* Fixed a bug in `send_game_state` by correcting the size of the buffer passed to the debug function. (`bonus/server/send_game_messages.c`)
* Removed unnecessary decrement of `server->client_count` in `close_everything`, as the loop already handles client cleanup. (`bonus/server/server.c`)